### PR TITLE
We increase the fee of OP_RETURN transaction up to ~ 205 satoshi/byte…

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -22,7 +22,7 @@ import binascii
 from pycoin.tx.UnsignedTx import UnsignedTxOut
 from pycoin.serialize import b2h
 
-TX_FEES = 10000
+TX_FEES = 50000
 BLOCKCHAIN_DUST = 5430
 B2S = 100000000
 


### PR DESCRIPTION
Hi,

Please accept this patch
As i understood it will increase fee of OP_RETURN transaction up to normal comission (0.5 mBTC)
You will get 5-0.5=4.5 mBTC for this in anyway ;-)